### PR TITLE
Refactor: Use environment variable for Brave API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Deploy MCP services with these steps:
    cp .env.example .env
    ```
 
-   - Edit `.env` for any necessary environment variables for services other than Brave Search.
-   - For Brave Search: Create a file named `brave_api_key.txt` in the project root and paste your API key into it. This file is used by Docker Secrets (see Security Considerations).
+   - Edit `.env` to set your environment variables. This includes setting `BRAVE_API_KEY=your_api_key_here` for the Brave Search service, along with any other necessary variables.
 
 4. **Start Services**:
 
@@ -112,7 +111,7 @@ Deploy MCP services with these steps:
 - `LICENSE`: MIT License.
 - `mcp_services/`: Node.js service code.
 - `view/`: Mapped to `mcp-filesystem` container.
-- `.env.example`, `.env`: Environment variables. `brave_api_key.txt` is used for the Brave Search API key (see Security Considerations).
+ - `.env.example`, `.env`: Environment variables. The `BRAVE_API_KEY` for the Brave Search service is configured in the `.env` file (copied from `.env.example`).
 - `start.sh`, `start.bat`, `stop.sh`, `stop.bat`: Start/stop scripts.
 
 ## Troubleshooting
@@ -138,20 +137,15 @@ The `docker-compose.yml` file incorporates the following security measures:
 -   **Non-Root Users**: All services are configured to run as a non-root user (`1000:1000`) to reduce potential damage if a container is compromised.
 -   **Resource Limits**: Each service has `mem_limit` and `cpus` constraints defined to prevent resource exhaustion and denial-of-service scenarios.
 -   **Network Isolation**: Services are placed on a custom Docker network (`mcp-net`), which can be further configured to restrict inter-service communication if needed.
--   **Secrets Management (Brave Search)**: The Brave Search API key is managed using Docker Secrets via the `brave_api_key.txt` file. This is more secure than using environment variables directly for sensitive data.
+ -   **Secrets Management (Brave Search)**: The Brave Search API key is configured via the `BRAVE_API_KEY` environment variable, which should be set in the `.env` file. For production, consider more robust secrets management like HashiCorp Vault or cloud provider solutions.
 -   **Read-Only Volumes**: The `mcp-filesystem` service mounts its `./view` directory as read-only (`ro`) to prevent unauthorized modifications to these files from within the container.
 
 ### Managing Secrets
 
-The Brave Search API key is handled via Docker Secrets. You must create a file named `brave_api_key.txt` in the root directory of this project and place your API key there.
-```
-# Example: brave_api_key.txt
-YOUR_ACTUAL_BRAVE_SEARCH_API_KEY
-```
-This file is ignored by Git (see `.gitignore`). For production environments, consider using more robust secrets management tools like HashiCorp Vault or cloud provider-specific solutions.
+The Brave Search API key is now defined in the `.env` file (copied from `.env.example`) using the `BRAVE_API_KEY` variable. This key is then passed as an environment variable to the `mcp-brave-search` service.
+For production environments, it is highly recommended to use more robust secrets management tools like HashiCorp Vault or cloud provider-specific solutions instead of relying solely on `.env` files.
 
-Further information on Docker Secrets:
--   [Docker Secrets Documentation](https://docs.docker.com/engine/swarm/secrets/)
+While Docker Secrets is a valid approach for managing sensitive data (and you can learn more about it [here](https://docs.docker.com/engine/swarm/secrets/)), this project has been simplified to use environment variables for the Brave Search API key for easier setup.
 
 ### Brave Search Service Security (`./mcp-services/src/brave-search/`)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -27,7 +27,7 @@
    cp .env.example .env
    ```
 
-   - 編輯 `.env`，填入 Brave Search API 金鑰。
+   - 編輯 `.env` 檔案，設定您的環境變數。這包括為 Brave Search 服務設定 `BRAVE_API_KEY=您的API金鑰`，以及其他任何必要的變數。
 
 4. **啟動服務**：
 
@@ -113,7 +113,7 @@
 - `LICENSE`：MIT 授權。
 - `mcp-services/`：Node.js 服務原始碼。
 - `view/`：映射至 `mcp-filesystem` 容器。
-- `.env.example`, `.env`：環境變數。
+ - `.env.example`, `.env`：環境變數。Brave Search 服務的 `BRAVE_API_KEY` 在 `.env` 檔案中設定 (從 `.env.example` 複製)。
 - `start.sh`, `start.bat`, `stop.sh`, `stop.bat`：啟動/停止腳本。
 
 ## 疑難排解

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,13 +34,11 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=8083
-      - BRAVE_SEARCH_API_KEY_FILE=/run/secrets/brave_api_key
+      - BRAVE_API_KEY=${BRAVE_API_KEY}
     ports:
       - "8083:8083"
     networks:
       - mcp-net
-    secrets:
-      - brave_api_key
     tty: true
     stdin_open: true
 
@@ -107,7 +105,3 @@ networks:
     # Add internal: true if services should only communicate with each other and not externally,
     # except through explicitly mapped ports. For this task, we'll assume default bridge behavior is fine
     # unless further restrictions are needed.
-
-secrets:
-  brave_api_key:
-    file: ./brave_api_key.txt


### PR DESCRIPTION
This commit changes the configuration of the Brave Search API key. Instead of using Docker Secrets and a `brave_api_key.txt` file, the `mcp-brave-search` service in `docker-compose.yml` now uses an environment variable `BRAVE_API_KEY`.

You should define `BRAVE_API_KEY` in your `.env` file.

The following files were updated:
- `docker-compose.yml`: Modified to source `BRAVE_API_KEY` from the environment and removed Docker Secrets configuration for this key.
- `README.md`: Updated setup instructions and security considerations to reflect the new method.
- `README.zh-TW.md`: Updated setup instructions to align with the new method.
- `.gitignore`: Verified to ensure `brave_api_key.txt` remains ignored to prevent accidental commits of old user files.

The `mcp-services/src/brave-search/index.ts` already supported reading from the `BRAVE_API_KEY` environment variable, so no changes were needed there.